### PR TITLE
Possibility to instantiate TSIClient from env variables

### DIFF
--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import os
 import json
 import pandas as pd
 import requests
@@ -16,6 +17,9 @@ class TSIClient():
     is retrieved in form of a pandas dataframe, which allows subsequent analysis
     by data analysts, data scientists and developers.
 
+    It can be instantiated either by arguments or by environment variables (if env
+    variables are set, they take precedence even when function arguments are specified).
+
     Args:
         enviroment (str): The name of the Azure TSI environment.
         client_id (str): The client id of the service principal used to authenticate with Azure TSI.
@@ -23,7 +27,7 @@ class TSIClient():
         tenant_id (str): The tenant id of the service principal used to authenticate with Azure TSI.
         applicationName (str): The name can be an arbitrary string. For informational purpose.
 
-    Example:
+    Examples:
         The TSIClient is the entry point to the SDK. You can instantiate it like this:
 
             >>> from TSIClient import TSIClient as tsi
@@ -34,15 +38,36 @@ class TSIClient():
             ...     tenant_id="<your-tenant-id>",
             ...     applicationName="<your-app-name>">
             ... )
+
+        You might find it useful to specify environment variables to instantiate the TSIClient.
+        To do so, you need to set the following environment variables:
+
+        * ``TSICLIENT_APPLICATION_NAME``
+        * ``TSICLIENT_ENVIRONMENT_NAME``
+        * ``TSICLIENT_CLIENT_ID``
+        * ``TSICLIENT_CLIENT_SECRET``
+        * ``TSICLIENT_TENANT_ID``
+        
+        Now you can instantiate the TSIClient without passing any arguments:
+
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
     """
 
-    def __init__(self, enviroment, client_id, client_secret, applicationName, tenant_id):
+    def __init__(
+            self,
+            enviroment=None,
+            client_id=None,
+            client_secret=None,
+            applicationName=None,
+            tenant_id=None
+        ):
         self._apiVersion = "2018-11-01-preview"
-        self._applicationName = applicationName
-        self._enviromentName = enviroment
-        self._client_id = client_id
-        self._client_secret=client_secret
-        self._tenant_id = tenant_id
+        self._applicationName = os.getenv("TSICLIENT_APPLICATION_NAME", applicationName)
+        self._enviromentName = os.getenv("TSICLIENT_ENVIRONMENT_NAME", enviroment)
+        self._client_id = os.getenv("TSICLIENT_CLIENT_ID", client_id)
+        self._client_secret = os.getenv("TSICLIENT_CLIENT_SECRET", client_secret)
+        self._tenant_id = os.getenv("TSICLIENT_TENANT_ID", tenant_id)
 
 
     def _getToken(self):

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -121,6 +121,11 @@ class TSIClient():
 
         Raises:
             TSIEnvironmentError: Raised if the TSI environment does not exist.
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> env = client.getEnviroment()
         """
 
         authorizationToken = self._getToken()
@@ -164,6 +169,11 @@ class TSIClient():
 
         Returns:
             dict: The environment availability. Contains interval size, distribution and range.
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> env_availability = client.getEnvironmentAvailability()
         """
 
         environmentId = self.getEnviroment()
@@ -205,6 +215,11 @@ class TSIClient():
         Returns:
             dict: The instances in form of the response from the TSI api call.
             Contains typeId, timeSeriesId, name, description, hierarchyIds and instanceFields per instance.
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> instances = client.getInstances()
         """
 
         environmentId = self.getEnviroment()
@@ -251,6 +266,11 @@ class TSIClient():
         Returns:
             dict: The hierarchies in form of the response from the TSI api call.
             Contains hierarchy id, names and source fields per hierarchy.
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> hierarchies = client.getHierarchies()
         """
 
         environmentId = self.getEnviroment()
@@ -292,6 +312,11 @@ class TSIClient():
         Returns:
             dict: The types in form of the response from the TSI api call.
             Contains id, name, description and variables per type.
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> types = client.getTypes()
         """
         
         environmentId = self.getEnviroment()

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -26,6 +26,24 @@ multiple TSI environments, you need to create multiple instances of the TSIClien
     ...     applicationName="<your-app-name>">
     ... )
 
+Alternatively, you can use environment variables to instantiate the TSIClient.
+Set the following variables (commands for Mac/Linux):
+
+.. code-block:: console
+
+    $ export TSICLIENT_APPLICATION_NAME=<your-app-name>
+    $ export TSICLIENT_ENVIRONMENT_NAME=<your-tsi-env-name>
+    $ export TSICLIENT_CLIENT_ID=<your-client-id>
+    $ export TSICLIENT_CLIENT_SECRET=<your-client-secret>
+    $ export TSICLIENT_TENANT_ID=<your-tenant-id>
+
+Now you can instantiate the TSIClient without passing any arguments. Be aware
+that the environment variables take precedence over the arguments.
+
+.. code-block:: python
+
+    >>> from TSIClient import TSIClient as tsi
+    >>> client = tsi.TSIClient()
 
 You can verify that the TSIClient is pointing at the right TSI environment by running the
 following command. It returns the environment id, which you can compare with your data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from TSIClient import TSIClient as tsi
 
@@ -13,3 +14,14 @@ def client():
     )
 
     return client
+
+
+@pytest.fixture(scope="module")
+def client_from_env():
+    os.environ["TSICLIENT_APPLICATION_NAME"] = "my_app"
+    os.environ["TSICLIENT_ENVIRONMENT_NAME"] = "my_environment"
+    os.environ["TSICLIENT_CLIENT_ID"] = "my_client_id"
+    os.environ["TSICLIENT_CLIENT_SECRET"] = "my_client_secret"
+    os.environ["TSICLIENT_TENANT_ID"] = "my_tenant_id"
+
+    return tsi.TSIClient()

--- a/tests/test_tsiclient.py
+++ b/tests/test_tsiclient.py
@@ -123,7 +123,19 @@ class MockResponses():
 
 class TestTSIClient():
     def test_create_TSICLient_success(self, client):
-        assert client
+        assert client._applicationName == "postmanServicePrincipal"
+        assert client._enviromentName == "Test_Environment"
+        assert client._client_id == "MyClientID"
+        assert client._client_secret == "a_very_secret_password"
+        assert client._tenant_id == "yet_another_tenant_id"
+
+
+    def test_instantiate_TSIClient_from_env(self, client_from_env):
+        assert client_from_env._applicationName == "my_app"
+        assert client_from_env._enviromentName == "my_environment"
+        assert client_from_env._client_id == "my_client_id"
+        assert client_from_env._client_secret == "my_client_secret"
+        assert client_from_env._tenant_id == "my_tenant_id"
 
 
     def test__getToken_success(self, requests_mock, client):


### PR DESCRIPTION
Hi,

See PR header + unit test for the same. This might be a more convenient way to instantiate the TSIClient, depending on user preference.

The regular way of passing arguments to the constructor is still allowed. 

Best regards, 
Rafael