### PR TITLE
General refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ data = client.getDataById(
     timespan=["2019-12-12T15:35:11.68Z", "2019-12-12T17:02:05.958Z"],
     interval="PT5M",
     aggregate="avg",
-    use_warm_store=False
+    useWarmStore=False
 )
 ````
 

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -607,11 +607,22 @@ class TSIClient():
             useWarmStore (bool): If True, the query is executed on the warm storage (free of charge), otherwise on the cold storage. Defaults to False.
 
         Returns:
-            A pandas dataframe with timeseries data.
+            A pandas dataframe with timeseries data. Columns are ordered the same way as the variable names.
 
         Raises:
             TSIStoreError: Raised if the was tried to execute on the warm store, but the warm store is not enabled.
             TSIQueryError: Raised if there was an error in the query arguments (e.g. wrong formatting).
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> data = client.getDataByName(
+            ...     variables=["timeseries_name_1", "timeseries_name_2"],
+            ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
+            ...     interval="PT5M",
+            ...     aggregate="avg",
+            ...     useWarmStore=False
+            ... )
         """
 
         environmentId = self.getEnviroment()
@@ -643,6 +654,7 @@ class TSIClient():
         Args:
             variables (list): The variable descriptions. Corresponds to the "description" field of the time series instances.
             TSName (list): The column names for the refurned dataframe. Must be in the same order as the variable descriptions.
+                These names can be arbitrary and do not need to coincide with the timeseries names in TSI. 
             timespan (list): A list of two timestamps. First list element ist the start time, second element is the end time.
                 Example: timespan=['2019-12-12T15:35:11.68Z', '2019-12-12T17:02:05.958Z']
             interval (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
@@ -651,11 +663,23 @@ class TSIClient():
             useWarmStore (bool): If True, the query is executed on the warm storage (free of charge), otherwise on the cold storage. Defaults to False.
 
         Returns:
-            A pandas dataframe with timeseries data.
+            A pandas dataframe with timeseries data. Columns are ordered the same way as the variable descriptions.
 
         Raises:
             TSIStoreError: Raised if the was tried to execute on the warm store, but the warm store is not enabled.
             TSIQueryError: Raised if there was an error in the query arguments (e.g. wrong formatting).
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> data = client.getDataByDescription(
+            ...     variables=["timeseries_description_1", "timeseries_description_2"],
+            ...     TSName=["my_timeseries_name_1", "my_timeseries_name_2"]
+            ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
+            ...     interval="PT5M",
+            ...     aggregate="avg",
+            ...     useWarmStore=False
+            ... )
         """
 
         environmentId = self.getEnviroment()
@@ -693,11 +717,22 @@ class TSIClient():
             useWarmStore (bool): If True, the query is executed on the warm storage (free of charge), otherwise on the cold storage. Defaults to False.
 
         Returns:
-            A pandas dataframe with timeseries data.
+            A pandas dataframe with timeseries data. Columns are ordered the same way as the timeseries ids.
 
         Raises:
             TSIStoreError: Raised if the was tried to execute on the warm store, but the warm store is not enabled.
             TSIQueryError: Raised if there was an error in the query arguments (e.g. wrong formatting).
+
+        Example:
+            >>> from TSIClient import TSIClient as tsi
+            >>> client = tsi.TSIClient()
+            >>> data = client.getDataById(
+            ...     timeseries=["timeseries_id_1", "timeseries_id_2"],
+            ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
+            ...     interval="PT5M",
+            ...     aggregate="avg",
+            ...     useWarmStore=False
+            ... )
         """
 
         environmentId = self.getEnviroment()

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -113,7 +113,7 @@ class TSIClient():
         return authorizationToken
 
 
-    def _create_querystring(self, useWarmStore=None):
+    def _getQueryString(self, useWarmStore=None):
         """Creates the querystring for an api request.
         
         Can be used in all api requests in TSIClient.
@@ -154,7 +154,7 @@ class TSIClient():
         authorizationToken = self._getToken()
         url = "https://api.timeseries.azure.com/environments"
         
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         
         payload = ""
         headers = {
@@ -204,7 +204,7 @@ class TSIClient():
         url = "https://{environmentId}.env.timeseries.azure.com/availability".format(
             environmentId=environmentId,
         )
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         payload = ""
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -250,7 +250,7 @@ class TSIClient():
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/"
         
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         payload = ""
         
         headers = {
@@ -300,7 +300,7 @@ class TSIClient():
         authorizationToken = self._getToken()
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/hierarchies"
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         payload = ""
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -346,7 +346,7 @@ class TSIClient():
         authorizationToken = self._getToken()
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/types"
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         payload = ""
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -392,7 +392,7 @@ class TSIClient():
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/$batch"
         
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
 
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -421,7 +421,7 @@ class TSIClient():
         payload = {"delete":{"timeSeriesIds":instancesList}}
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/$batch"
         
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -453,7 +453,7 @@ class TSIClient():
         payload = {"delete":{"timeSeriesIds":instancesList}}
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/$batch"
 
-        querystring = self._create_querystring()
+        querystring = self._getQueryString()
         
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -591,7 +591,7 @@ class TSIClient():
         authorizationToken = self._getToken()
         df = None
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
-        querystring = self._create_querystring(useWarmStore=useWarmStore)
+        querystring = self._getQueryString(useWarmStore=useWarmStore)
         timeseries = self.getIdByName(variables)
         if aggregate != None:
             aggregate = {"tsx": "{0!s}($value)".format(aggregate)}
@@ -690,7 +690,7 @@ class TSIClient():
         authorizationToken = self._getToken()
         df = None
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
-        querystring = self._create_querystring(useWarmStore=useWarmStore)
+        querystring = self._getQueryString(useWarmStore=useWarmStore)
         timeseries = self.getIdByDescription(variables)
         if aggregate != None:
             aggregate = {"tsx": "{0!s}($value)".format(aggregate)}
@@ -789,7 +789,7 @@ class TSIClient():
         authorizationToken = self._getToken()
         df = None
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
-        querystring = self._create_querystring(useWarmStore=useWarmStore)
+        querystring = self._getQueryString(useWarmStore=useWarmStore)
         if aggregate != None:
             aggregate = {"tsx": "{0!s}($value)".format(aggregate)}
             dict_key = "aggregateSeries"

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -435,7 +435,7 @@ class TSIClient():
         # Test if response body contains sth.
         if response.text:
             jsonResponse = json.loads(response.text)
-        
+
         return jsonResponse
 
 
@@ -514,7 +514,7 @@ class TSIClient():
                 timeSeriesIds.append(instance['timeSeriesId'][0])
             else:
                 continue#timeSeriesIds.append(None)
-        return timeSeriesIds    
+        return timeSeriesIds
 
 
     def getIdByName(self, names):
@@ -593,12 +593,17 @@ class TSIClient():
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
         querystring = self._create_querystring(useWarmStore=useWarmStore)
         timeseries = self.getIdByName(variables)
+        if aggregate != None:
+            aggregate = {"tsx": "{0!s}($value)".format(aggregate)}
+            dict_key = "aggregateSeries"
+        else:
+            dict_key = "getSeries"
         for i, _ in enumerate(timeseries):
             if timeseries[i] == None:
                 logging.error("No such tag: {tag}".format(tag=variables[i]))
                 continue
             payload = {
-                "aggregateSeries": {
+                dict_key: {
                     "timeSeriesId": [timeseries[i]],
                     "timeSeriesName": None,
                     "searchSpan": {"from": timespan[0], "to": timespan[1]},
@@ -609,7 +614,7 @@ class TSIClient():
                             "kind": "numeric",
                             "value": {"tsx": "$event.value"},
                             "filter": None,
-                            "aggregation": {"tsx": "{0!s}($value)".format(aggregate)},
+                            "aggregation": aggregate,
                         },
                     },
                     "projectedVariables": ["AverageTest"],
@@ -630,7 +635,6 @@ class TSIClient():
                 params=querystring,
             )
 
-            # Test if response body contains sth.
             if response.text:
                 response = json.loads(response.text)
                 if "error" in response:
@@ -731,7 +735,6 @@ class TSIClient():
                 params=querystring,
             )
 
-            # Test if response body contains sth.
             if response.text:
                 response = json.loads(response.text)
                 if "error" in response:

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -32,13 +32,14 @@ to activate the virtual environment.
 Testing
 #######
 We use ``pytest`` for testing and ``requests-mock`` for mocking api calls
-to the TSI APIs within unittests.
+to the TSI APIs within unittests. You can can get code coverage per file
+by using the ``--cov`` argument (this requires ``pytest-cov``).
 
 You can run tests with:
 
 .. code-block:: console
 
-    $ python -m pytest -v
+    $ python -m pytest -v --cov=./TSIClient
 
 
 Docstrings & Documentation

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -91,10 +91,10 @@ is convenient for further statistical analysis.
     ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
     ...     interval="PT5M",
     ...     aggregate="avg",
-    ...     use_warm_store=False
+    ...     useWarmStore=False
     ... )
     >>> data
-    timestamp                   timeseries_id1  timeseries_id2  
+    timestamp                   timeseries_id1  timeseries_id2
     0    2020-01-25T10:00:00Z       360.272727      242.692308
     1    2020-01-25T10:05:00Z       362.588235      244.523810
     2    2020-01-25T10:10:00Z       369.280000      245.000000

--- a/tests/test_tsiclient.py
+++ b/tests/test_tsiclient.py
@@ -60,6 +60,26 @@ class TestTSIClient():
             client._getToken()
 
 
+    def test__getVariableAggregate(self, requests_mock, client):
+        aggregate, requestType = client._getVariableAggregate(aggregate=None)
+        
+        assert aggregate == None
+        assert requestType == "getSeries"
+
+
+    def test__getVariableAggregate(self, requests_mock, client, caplog):
+        with pytest.raises(TSIQueryError):
+            client._getVariableAggregate(aggregate="unsupported_aggregate")
+
+
+    def test__getVariableAggregate(self, requests_mock, client):
+        aggregate, requestType = client._getVariableAggregate(aggregate="avg")
+        
+        assert aggregate == {'tsx': 'avg($value)'}
+        assert isinstance(aggregate, dict)
+        assert requestType == "aggregateSeries"
+
+
     def test_getEnvironment_success(self, requests_mock, client):
         requests_mock.request(
             "POST",

--- a/tests/test_tsiclient.py
+++ b/tests/test_tsiclient.py
@@ -60,19 +60,19 @@ class TestTSIClient():
             client._getToken()
 
 
-    def test__getVariableAggregate(self, requests_mock, client):
+    def test__getVariableAggregate_with_no_aggregate_returns_None_and_getSeries(self, requests_mock, client):
         aggregate, requestType = client._getVariableAggregate(aggregate=None)
         
         assert aggregate == None
         assert requestType == "getSeries"
 
 
-    def test__getVariableAggregate(self, requests_mock, client, caplog):
+    def test__getVariableAggregate_with_unsupported_aggregate_raises_TSIQueryError(self, requests_mock, client, caplog):
         with pytest.raises(TSIQueryError):
             client._getVariableAggregate(aggregate="unsupported_aggregate")
 
 
-    def test__getVariableAggregate(self, requests_mock, client):
+    def test__getVariableAggregate_with_avg_aggregate_returns_aggregate_and_aggregateSeries(self, requests_mock, client):
         aggregate, requestType = client._getVariableAggregate(aggregate="avg")
         
         assert aggregate == {'tsx': 'avg($value)'}

--- a/tests/test_tsiclient.py
+++ b/tests/test_tsiclient.py
@@ -601,6 +601,60 @@ class TestTSIClient():
             )
 
 
+    def test_getDataById_raises_HTTPError(self, requests_mock, client):
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        requests_mock.request(
+            "GET",
+            MockURLs.env_url,
+            json=MockResponses.mock_environments
+        )
+        requests_mock.request(
+            "POST",
+            MockURLs.query_getseries_url,
+            exc=requests.exceptions.HTTPError
+        )
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            data_by_id = client.getDataById(
+                timeseries=["006dfc2d-0324-4937-998c-d16f3b4f1952"],
+                timespan=["2016-08-01T00:00:10Z", "2016-08-01T00:00:20Z"],
+                interval="PT1S",
+                aggregate="avg",
+                useWarmStore=False
+            )
+
+
+    def test_getDataById_raises_ConnectTimeout(self, requests_mock, client):
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        requests_mock.request(
+            "GET",
+            MockURLs.env_url,
+            json=MockResponses.mock_environments
+        )
+        requests_mock.request(
+            "POST",
+            MockURLs.query_getseries_url,
+            exc=requests.exceptions.ConnectTimeout
+        )
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            data_by_id = client.getDataById(
+                timeseries=["006dfc2d-0324-4937-998c-d16f3b4f1952"],
+                timespan=["2016-08-01T00:00:10Z", "2016-08-01T00:00:20Z"],
+                interval="PT1S",
+                aggregate="avg",
+                useWarmStore=False
+            )
+
+
     def test_getDataByDescription_returns_data_as_dataframe(self, requests_mock, client):
         requests_mock.request(
             "POST",

--- a/tests/test_tsiclient.py
+++ b/tests/test_tsiclient.py
@@ -396,6 +396,51 @@ class TestTSIClient():
         assert timeSeriesNames[1] == None
 
 
+    def test_getIdByAssets_with_one_existing_asset_returns_correct_id(self, requests_mock, client):
+        requests_mock.request(
+            "GET",
+            MockURLs.instances_url,
+            json=MockResponses.mock_instances
+        )
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        requests_mock.request(
+            "GET",
+            MockURLs.env_url,
+            json=MockResponses.mock_environments
+        )
+
+        timeSeriesIds = client.getIdByAssets(asset="F1W7")
+
+        assert len(timeSeriesIds) == 1
+        assert timeSeriesIds[0] == "006dfc2d-0324-4937-998c-d16f3b4f1952"
+
+
+    def test_getIdByAssets_with_non_existant_assets_returns_empty_list(self, requests_mock, client):
+        requests_mock.request(
+            "GET",
+            MockURLs.instances_url,
+            json=MockResponses.mock_instances
+        )
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        requests_mock.request(
+            "GET",
+            MockURLs.env_url,
+            json=MockResponses.mock_environments
+        )
+
+        timeSeriesIds = client.getIdByAssets(asset="made_up_asset_name")
+
+        assert len(timeSeriesIds) == 0
+
+
     def test_getIdByName_with_one_correct_name_returns_correct_id(self, requests_mock, client):
         requests_mock.request(
             "GET",


### PR DESCRIPTION
This PR contains:
- a fixed typo in `userguide.rst`
- a private method `_getVariableAggregate()` which is used to create the aggregation dict for the payload, this method can be shared among all `getDataBy...()` methods
- renamed private method `_create_querystring()` to `_getQueryString()`, this has no influence on the user
- all `getDataBy...()` methods now allow to retrieve raw timeseries (`aggregate` argument defaults to `None`, in which case `getSeries` is used instead of `aggregateSeries`
- reduced code duplication by introducing a private `_getData()` method, which contains the shared code from all 3 `getDataBy...()` methods
- unit tests for `_getVariableAggregate()` and `_getIdByAssets()`